### PR TITLE
Settings/colour options

### DIFF
--- a/src/app/Http/Controllers/AccessibilityController.php
+++ b/src/app/Http/Controllers/AccessibilityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Helpers\ColourPalletHelper;
 use App\Http\Helpers\FontSizeHelper;
 use Illuminate\Http\Request;
 
@@ -17,9 +18,11 @@ class AccessibilityController extends Controller
 
         // get the font scale from post request
         $fontScale = request()->get('font_scale');
+        $headerColour = request()->get('header_colour');
 
         // update the font scale using the helper method
         FontSizeHelper::setSizeScale($fontScale);
+        ColourPalletHelper::setHeaderColour($headerColour);
 
         // redirect the user to the landing page
         return redirect()->route('landing.get');

--- a/src/app/Http/Controllers/AccessibilityController.php
+++ b/src/app/Http/Controllers/AccessibilityController.php
@@ -19,10 +19,12 @@ class AccessibilityController extends Controller
         // get the font scale from post request
         $fontScale = request()->get('font_scale');
         $headerColour = request()->get('header_colour');
+        $fontColour = request()->get('font_colour');
 
         // update the font scale using the helper method
         FontSizeHelper::setSizeScale($fontScale);
         ColourPalletHelper::setHeaderColour($headerColour);
+        ColourPalletHelper::setFontColour($fontColour);
 
         // redirect the user to the landing page
         return redirect()->route('landing.get');

--- a/src/app/Http/Helpers/ColourPalletHelper.php
+++ b/src/app/Http/Helpers/ColourPalletHelper.php
@@ -6,11 +6,19 @@ class ColourPalletHelper {
 
     const DEFAULT_HEADER_COLOUR = '#887bb0';
     const HEADER_COLOUR = 'SESSION_HEADER_COLOUR';
+    const DEFAULT_FONT_COLOUR = '#000000';
+    const FONT_COLOUR = 'SESSION_FONT_COLOUR';
 
     // sets the header colour
     public static function setHeaderColour($newColour)
     {
         return session()->put(self::HEADER_COLOUR, $newColour);
+    }
+
+    // sets the font colour
+    public static function setFontColour($newColour)
+    {
+        return session()->put(self::FONT_COLOUR, $newColour);
     }
 
     // returns the header colour
@@ -19,9 +27,21 @@ class ColourPalletHelper {
         return session()->get(self::HEADER_COLOUR, self::DEFAULT_HEADER_COLOUR);
     }
 
+    // returns the font colour
+    public static function getFontColour()
+    {
+        return session()->get(self::FONT_COLOUR, self::DEFAULT_FONT_COLOUR);
+    }
+
     // returns the header styling
     public static function getHeaderStyle()
     {
         return 'style="background: ' . self::getHeaderColour() . '; opacity: 80%"';
+    }
+
+    // returns the font colour styling
+    public static function getFontColourStyle()
+    {
+        return 'color: ' . self::getFontColour() . ';';
     }
 }

--- a/src/app/Http/Helpers/ColourPalletHelper.php
+++ b/src/app/Http/Helpers/ColourPalletHelper.php
@@ -44,4 +44,9 @@ class ColourPalletHelper {
     {
         return 'color: ' . self::getFontColour() . ';';
     }
+
+    public static function getFontColourStyleHeading()
+    {
+        return 'color: ' . self::getFontColour() . '; filter: invert(100%);';
+    }
 }

--- a/src/app/Http/Helpers/ColourPalletHelper.php
+++ b/src/app/Http/Helpers/ColourPalletHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Helpers;
+
+class ColourPalletHelper {
+
+    const DEFAULT_HEADER_COLOUR = '#887bb0';
+    const HEADER_COLOUR = 'SESSION_HEADER_COLOUR';
+
+    // sets the header colour
+    public static function setHeaderColour($newColour)
+    {
+        return session()->put(self::HEADER_COLOUR, $newColour);
+    }
+
+    // returns the header colour
+    public static function getHeaderColour()
+    {
+        return session()->get(self::HEADER_COLOUR, self::DEFAULT_HEADER_COLOUR);
+    }
+
+    // returns the header styling
+    public static function getHeaderStyle()
+    {
+        return 'style="background: ' . self::getHeaderColour() . '; opacity: 80%"';
+    }
+}

--- a/src/resources/views/accessibility-settings.blade.php
+++ b/src/resources/views/accessibility-settings.blade.php
@@ -31,6 +31,12 @@
         <label for="input_font_size" class="form-label pb-0 mb-0"><b>Font Size</b></label>
         <small class="d-block" id="text_font_size_help">Displaying text at {{ \App\Http\Helpers\FontSizeHelper::getSizeScale() }}% of original size.</small>
         <input type="range" class="form-range" min="0" max="100" step="10" value="{{ \App\Http\Helpers\FontSizeHelper::getExcludingSizeScale() }}" id="input_font_size" name="font_scale">
+
+        <!-- Header Colour Input -->
+        <label for="input_colour_pallet" class="form-label pb-0 mb-0"><b>Customise Header</b></label>
+        <br>
+        <input type="color" name="header_colour" id="input_colour_pallet" value="{!! \App\Http\Helpers\ColourPalletHelper::getHeaderColour() !!}" />
+
         <button type="submit" class="btn btn-lg btn-outline-dark container-fluid align-text-bottom">Save</button>
     </form>
 </div>

--- a/src/resources/views/accessibility-settings.blade.php
+++ b/src/resources/views/accessibility-settings.blade.php
@@ -33,9 +33,16 @@
         <input type="range" class="form-range" min="0" max="100" step="10" value="{{ \App\Http\Helpers\FontSizeHelper::getExcludingSizeScale() }}" id="input_font_size" name="font_scale">
 
         <!-- Header Colour Input -->
-        <label for="input_colour_pallet" class="form-label pb-0 mb-0"><b>Customise Header</b></label>
+        <label for="input_colour_header" class="form-label pb-0 mb-0"><b>Customise Header Colour</b></label>
         <br>
-        <input type="color" name="header_colour" id="input_colour_pallet" value="{!! \App\Http\Helpers\ColourPalletHelper::getHeaderColour() !!}" />
+        <input type="color" name="header_colour" id="input_colour_header" value="{!! \App\Http\Helpers\ColourPalletHelper::getHeaderColour() !!}" />
+        <br>
+
+        <!-- Font Colour Input-->
+        <label for="input_colour_font" class="form-label pb-0 mb-0"><b>Customise Font Colour</b></label>
+        <br>
+        <input type="color" name="font_colour" id="input_colour_font" value="{!! \App\Http\Helpers\ColourPalletHelper::getFontColour() !!}" />
+        <br>
 
         <button type="submit" class="btn btn-lg btn-outline-dark container-fluid align-text-bottom">Save</button>
     </form>

--- a/src/resources/views/accessibility-settings.blade.php
+++ b/src/resources/views/accessibility-settings.blade.php
@@ -15,7 +15,7 @@
         </a>
     </div>
     <div class="col-8 container-fluid text-center">
-        <p class="mb-0 text-white"><b>Accessibility Settings</b></p>
+        <p class="mb-0" style="{!! \App\Http\Helpers\ColourPalletHelper::getFontColourStyleHeading() !!}"><b>Accessibility Settings</b></p>
     </div>
     <div class="col-2 container-fluid">
 
@@ -34,15 +34,11 @@
 
         <!-- Header Colour Input -->
         <label for="input_colour_header" class="form-label pb-0 mb-0"><b>Customise Header Colour</b></label>
-        <br>
         <input type="color" name="header_colour" id="input_colour_header" value="{!! \App\Http\Helpers\ColourPalletHelper::getHeaderColour() !!}" />
-        <br>
 
         <!-- Font Colour Input-->
         <label for="input_colour_font" class="form-label pb-0 mb-0"><b>Customise Font Colour</b></label>
-        <br>
         <input type="color" name="font_colour" id="input_colour_font" value="{!! \App\Http\Helpers\ColourPalletHelper::getFontColour() !!}" />
-        <br>
 
         <button type="submit" class="btn btn-lg btn-outline-dark container-fluid align-text-bottom">Save</button>
     </form>

--- a/src/resources/views/accessibility-settings.blade.php
+++ b/src/resources/views/accessibility-settings.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
 
-<div class="row p-2 pt-4" style="background: #887bb0; opacity: 80%">
+<div class="row p-2 pt-4" {!! \App\Http\Helpers\ColourPalletHelper::getHeaderStyle() !!}}>
     <div class="col-2 container-fluid">
         <a href="{{ url()->previous() }}" class="text-white">
             <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-arrow-left-circle-fill" viewBox="0 0 16 16">

--- a/src/resources/views/base.blade.php
+++ b/src/resources/views/base.blade.php
@@ -15,6 +15,12 @@
             {!! App\Http\Helpers\ColourPalletHelper::getFontColourStyle() !!};
         }
 
+
+        input {
+            width: 100%;
+            margin-bottom: 10px;
+        }
+
         .iphone {
             width: 21.06em;
             height: 35.6em;

--- a/src/resources/views/base.blade.php
+++ b/src/resources/views/base.blade.php
@@ -12,6 +12,7 @@
     <style>
         body {
             background: #c9c6e1;
+            {!! App\Http\Helpers\ColourPalletHelper::getFontColourStyle() !!};
         }
 
         .iphone {

--- a/src/resources/views/course.blade.php
+++ b/src/resources/views/course.blade.php
@@ -15,7 +15,7 @@
         </a>
     </div>
     <div class="col-8 container-fluid text-center">
-        <p class="mb-0 text-white"><b>{{request()['name']}} @if(request()['name'] != 'Help')Tutorial @endif</b></p>
+        <p class="mb-0" style="{!! \App\Http\Helpers\ColourPalletHelper::getFontColourStyleHeading() !!}"><b>{{request()['name']}} @if(request()['name'] != 'Help')Tutorial @endif</b></p>
     </div>
     <div class="col-2 container-fluid">
 

--- a/src/resources/views/course.blade.php
+++ b/src/resources/views/course.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
 
-<div class="row p-2 pt-4" style="background: #887bb0; opacity: 80%">
+<div class="row p-2 pt-4" {!! \App\Http\Helpers\ColourPalletHelper::getHeaderStyle() !!}}>
     <div class="col-2 container-fluid">
         <a href="{{ url()->previous() }}" class="text-white">
             <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-arrow-left-circle-fill" viewBox="0 0 16 16">

--- a/src/resources/views/landing.blade.php
+++ b/src/resources/views/landing.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
-    <div class="row p-2 pt-4" style="background: #887bb0; opacity: 80%">
+    <div class="row p-2 pt-4" {!! \App\Http\Helpers\ColourPalletHelper::getHeaderStyle() !!}}>
         <div class="col-2 container-fluid">
         </div>
         <div class="col-8 container-fluid text-center">

--- a/src/resources/views/landing.blade.php
+++ b/src/resources/views/landing.blade.php
@@ -9,7 +9,7 @@
         <div class="col-2 container-fluid">
         </div>
         <div class="col-8 container-fluid text-center">
-            <p class="mb-0 text-white"><b>Appsistant | Home</b></p>
+            <p class="mb-0" style="{!! \App\Http\Helpers\ColourPalletHelper::getFontColourStyleHeading() !!}"><b>Appsistant | Home</b></p>
         </div>
         <div class="col-2 container-fluid">
             <a href="{{ route('settings.get') }}" class="text-white">

--- a/src/resources/views/phone-home.blade.php
+++ b/src/resources/views/phone-home.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
-    <div class="p-3 pt-4" style="min-height: 100%; background: mintcream;">
+    <div class="p-3 pt-4" {!! \App\Http\Helpers\ColourPalletHelper::getHeaderStyle() !!}}>
         <div class="container">
             <div class="row my-2">
                 <div class="col-4">

--- a/src/resources/views/phone-home.blade.php
+++ b/src/resources/views/phone-home.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('content')
-    <div class="p-3 pt-4" {!! \App\Http\Helpers\ColourPalletHelper::getHeaderStyle() !!}}>
+    <div class="p-3 pt-4" style="min-height: 100%; background: mintcream;">
         <div class="container">
             <div class="row my-2">
                 <div class="col-4">


### PR DESCRIPTION
- Adds a customisable heading bar colour
<img width="324" alt="Screen Shot 2021-09-15 at 5 12 26 pm" src="https://user-images.githubusercontent.com/54053512/133387627-fb924074-be3d-47a4-be91-af839f01d1f2.png">

- Adds customisable font colour (the white headings are the invert of that colour)
<img width="317" alt="Screen Shot 2021-09-15 at 5 13 13 pm" src="https://user-images.githubusercontent.com/54053512/133387757-a8b10151-f799-4a0b-9f6f-e24c84d6d980.png">




